### PR TITLE
feat: tweak interface to signal module

### DIFF
--- a/fitstack/containers.py
+++ b/fitstack/containers.py
@@ -77,6 +77,12 @@ class MCMCFit(ContainerBase):
             "initialise": True,
             "distributed": False,
         },
+        "fixed": {
+            "axes": ["param"],
+            "dtype": np.bool,
+            "initialise": True,
+            "distributed": False,
+        },
         "autocorr_time": {
             "axes": ["param"],
             "dtype": np.float64,
@@ -140,6 +146,14 @@ class MCMCFit(ContainerBase):
         return samples
 
     @property
+    def fit_index(self):
+        return np.flatnonzero(~self.datasets["fixed"][:])
+
+    @property
+    def fixed_index(self):
+        return np.flatnonzero(self.datasets["fixed"][:])
+
+    @property
     def slice_chain(self):
         """Create a slice along the step axis that discards burn-in and thins.
 
@@ -147,7 +161,7 @@ class MCMCFit(ContainerBase):
         autocorrelation length divided by 2.
         """
 
-        tau = int(np.max(self.datasets["autocorr_time"][:]))
+        tau = int(np.max(self.datasets["autocorr_time"][:][self.fit_index]))
         thin = tau // 2
         discard = tau * 10
 

--- a/fitstack/mcmc.py
+++ b/fitstack/mcmc.py
@@ -38,7 +38,8 @@ def run_mcmc(
     normalize_template=False,
     mean_subtract=True,
     recompute_weight=True,
-    prior_spec=None,
+    model_kwargs=None,
+    param_spec=None,
     seed=None,
 ):
     """Fit a model to the source stack using an MCMC.
@@ -71,7 +72,7 @@ def run_mcmc(
         Polarisation to fit.  Here "I" refers to the weighted sum of the
          "XX" and "YY" polarisations and "joint" refers to a simultaneous
         fit to the "XX" and "YY" polarisations.
-    model_name : {"DeltaFunction"|"Exponential"|"ScaledShiftedTemplate"}
+    model_name : {"DeltaFunction"|"Exponential"|"ScaledShiftedTemplate"|"SimulationTemplate"}
         Name of the model to fit.  Specify the class name from the
         fitstack.models module.
     scale : float
@@ -102,9 +103,12 @@ def run_mcmc(
         This is only used when averaging the "XX" and "YY" polarisations to
         determine the "I" polarisation.  Otherwise whatever weight dataset
         is saved to the file will be used.  Default is True.
-    prior_spec : dict
+    param_spec : dict
         Dictionary that specifies the prior distribution for each parameter.
         See the docstring for the models.Model attribute for the correct format.
+    model_kwargs : dict
+        Dictionary that contains any keyword arguments that should be passed
+        to the model class at initialization.
     seed : int
         Seed to use for random number generation.  If the seed is not provided,
         then a random seed will be taken from system entropy.
@@ -123,17 +127,19 @@ def run_mcmc(
     required_pol = ["XX", "YY"]
     combine_pol = True
 
+    if param_spec is None:
+        param_spec = {}
+
+    if model_kwargs is None:
+        model_kwargs = {}
+
     # Load the data
     if isinstance(data, str):
-        data = utils.find_file(data)
-        pol_sel = utils.determine_pol_sel(data, pol=required_pol)
-        data = containers.FrequencyStackByPol.from_file(data, pol_sel=pol_sel)
+        data = utils.load_pol(utils.find_file(data), pol=required_pol)
 
     # Load the transfer function
     if transfer is not None and isinstance(transfer, str):
-        transfer = utils.find_file(transfer)
-        pol_sel = utils.determine_pol_sel(transfer, pol=required_pol)
-        transfer = containers.FrequencyStackByPol.from_file(transfer, pol_sel=pol_sel)
+        transfer = utils.load_pol(utils.find_file(transfer), pol=required_pol)
 
     # Load the templates
     if template is not None:
@@ -157,6 +163,13 @@ def run_mcmc(
                     for ax in container.weight.attrs["axis"]
                 )
                 container.weight[:] = inv_var[expand]
+
+    # For the simulation template we need to provide parameters to average the polarisations
+    if model_name == "SimulationTemplate":
+        model_kwargs["weight"] = inv_var if recompute_weight else data.weight[:]
+        model_kwargs["pol"] = required_pol
+        model_kwargs["combine"] = combine_pol
+        model_kwargs["sort"] = True
 
     # Determine the frequencies to fit
     freq = data.freq[:]
@@ -193,12 +206,11 @@ def run_mcmc(
         transfer_stack = transfer_stack[..., isort]
 
     if template is not None:
-        template_stack, _, _ = utils.initialize_pol(
-            template, pol=required_pol, combine=combine_pol
-        )
-
         # Use the mean value of the template over realizations
-        template_stack = scale * np.mean(template_stack, axis=0)[..., isort]
+        template = utils.average_stacks(
+            template, pol=required_pol, combine=combine_pol, sort=True
+        )
+        template_stack = scale * template.stack[:]
 
         if normalize_template:
             max_template = np.max(
@@ -215,7 +227,7 @@ def run_mcmc(
 
     # Prepare the model
     Model = getattr(models, model_name)
-    model = Model(seed=seed, **prior_spec)
+    model = Model(seed=seed, **{**model_kwargs, **param_spec})
 
     param_name = model.param_name
     nparam = len(param_name)
@@ -274,6 +286,9 @@ def run_mcmc(
     results["weight"][:] = weight_stack
     results["freq_flag"][:] = freq_flag
 
+    results["fixed"][:] = True
+    results["fixed"][:][model.fit_index] = False
+
     if transfer is not None:
         results.add_dataset("transfer_function")
         results["transfer_function"][:] = transfer_stack
@@ -319,6 +334,10 @@ def run_mcmc(
         fit_kwargs["template"] = template_stack[ipol]
         eval_kwargs["template"] = template_stack[:]
 
+    if model_name == "SimulationTemplate":
+        fit_kwargs["pol_sel"] = ipol
+        eval_kwargs["pol_sel"] = slice(None)
+
     model.set_data(**fit_kwargs)
 
     # Determine starting point for chains in parameter space
@@ -351,9 +370,13 @@ def run_mcmc(
 
     # Save the results to the output container
     results["chain"][:] = chain_all
-    results["autocorr_time"][:] = sampler.get_autocorr_time(quiet=True)
+
+    results["autocorr_time"][:] = 0.0
+    results["autocorr_time"][:][model.fit_index] = sampler.get_autocorr_time(quiet=True)
+
     results["acceptance_fraction"][:] = sampler.acceptance_fraction
-    results["model_min_chisq"][ipol] = model.model(theta_min, **eval_kwargs)
+
+    results["model_min_chisq"][:] = model.model(theta_min, **eval_kwargs)
 
     # Discard burn in and thin the chains
     flat_samples = results.samples(flat=True)
@@ -370,7 +393,7 @@ def run_mcmc(
     # Compute percentiles of the model
     mdl = np.zeros((flat_samples.shape[0], npol, nfreq), dtype=np.float32)
     for ss, theta in enumerate(flat_samples):
-        mdl[ss, ipol] = model.model(theta, **eval_kwargs)
+        mdl[ss] = model.model(theta, **eval_kwargs)
 
     results["model_percentile"][:] = np.percentile(mdl, PERCENTILE, axis=0).transpose(
         1, 2, 0
@@ -409,7 +432,8 @@ class RunMCMC(task.SingleTask):
     mean_subtract = config.Property(proptype=bool)
     recompute_weight = config.Property(proptype=bool)
 
-    prior_spec = config.Property(proptype=dict)
+    param_spec = config.Property(proptype=dict)
+    model_kwargs = config.Property(proptype=dict)
     seed = config.Property(proptype=int)
 
     def setup(self):

--- a/fitstack/models.py
+++ b/fitstack/models.py
@@ -1,4 +1,5 @@
 """Define models that can be fit to the source stack."""
+import inspect
 
 import numpy as np
 
@@ -69,9 +70,10 @@ class Model(object):
         self.seed = seed
         self.rng = np.random.Generator(np.random.SFC64(seed))
 
+        defaults = self.default_param_spec()
         self.param_spec = {}
-        for name, default_spec in self._param_spec.items():
-            self.param_spec[name] = param_spec.get(name, default_spec)
+        for name in self.param_name:
+            self.param_spec[name] = param_spec.get(name, defaults[name])
 
         self.priors = {}
         for name, spec in self.param_spec.items():
@@ -228,6 +230,31 @@ class Model(object):
     def nfit(self):
         """The number of parameters that are being fit."""
         return len(self.param_name_fit)
+
+    @classmethod
+    def default_param_spec(cls):
+        """Get the default parameter specification.
+
+        Combines the default parameter specifications in the _param_spec attribute
+        of all classes in the MRO, with base-class values overridden when the
+        parameter name is repeated in a subclass.  Hence, when creating a new class,
+        the full parameter specification dictionary does not need to be repeated if
+        only a few parameters are being modified.
+        """
+
+        param_spec = {}
+
+        # Iterate over the reversed MRO and look for _param_spec attributes
+        # which get added to a temporary dict. We go over the reversed MRO so
+        # that values in base classes are overridden.
+        for c in inspect.getmro(cls)[::-1]:
+
+            if hasattr(c, "_param_spec"):
+
+                for key, val in c._param_spec.items():
+                    param_spec[key] = val
+
+        return param_spec
 
 
 class ScaledShiftedTemplate(Model):
@@ -420,8 +447,10 @@ class Exponential(Model):
         return model
 
 
-class SimulationTemplateBase(Model):
+class SimulationTemplate(Model):
     """Fit the stack data to simulation templates."""
+
+    param_name = ["offset", "omega", "b_HI", "b_g", "NL", "FoGh", "FoGg", "M_10"]
 
     _param_spec = {
         "offset": {
@@ -429,66 +458,11 @@ class SimulationTemplateBase(Model):
             "value": 0.0,
             "prior": "Uniform",
             "kwargs": {
-                "low": -1.0,
-                "high": 1.0,
+                "low": -0.8,
+                "high": 0.8,
             },
         },
         "omega": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": -10.0,
-                "high": 10.0,
-            },
-        },
-        "b_HI": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": -10.0,
-                "high": 10.0,
-            },
-        },
-        # This is the only parameter which is reasonably constrained
-        "b_g": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": 0.0,
-                "high": 2.0,
-            },
-        },
-        "NL": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": -1.0,
-                "high": 2.0,
-            },
-        },
-        "FoGh": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": 0.0,
-                "high": 3.0,
-            },
-        },
-        "FoGg": {
-            "fixed": False,
-            "value": 1.0,
-            "prior": "Uniform",
-            "kwargs": {
-                "low": 0.0,
-                "high": 3.0,
-            },
-        },
-        "M_10": {
             "fixed": False,
             "value": 1.0,
             "prior": "Uniform",
@@ -497,50 +471,107 @@ class SimulationTemplateBase(Model):
                 "high": 5.0,
             },
         },
+        "b_HI": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Uniform",
+            "kwargs": {
+                "low": 0.0,
+                "high": 8.0,
+            },
+        },
+        # This is the only parameter which is reasonably constrained.
+        # Use scale = 0.03 for QSO, 0.13 for LRG, and 0.10 for ELG.
+        "b_g": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Gaussian",
+            "kwargs": {
+                "loc": 1.00,
+                "scale": 0.03,
+            },
+        },
+        "NL": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Uniform",
+            "kwargs": {
+                "low": -1.0,
+                "high": 7.0,
+            },
+        },
+        "FoGh": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Uniform",
+            "kwargs": {
+                "low": 0.0,
+                "high": 4.0,
+            },
+        },
+        "FoGg": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Uniform",
+            "kwargs": {
+                "low": 0.0,
+                "high": 4.0,
+            },
+        },
+        "M_10": {
+            "fixed": False,
+            "value": 1.0,
+            "prior": "Uniform",
+            "kwargs": {
+                "low": 0.0,
+                "high": 25.0,
+            },
+        },
     }
 
-    # Default base path
-    base_path = (
-        "/project/rpp-chime/chime/stacking/sims/analysis_stacks_comp/psbeam/psbeam/"
-    )
-
-    def __init__(self, *args, **kwargs):
-
-        pattern = (
-            self.base_path
-            + f"dataweight_compderiv*/post/datamask/{self.tracer}/{self.field}/"
-        )
-        factor = 1e3
+    def __init__(
+        self,
+        pattern,
+        factor=1e3,
+        pol=None,
+        weight=None,
+        combine=True,
+        sort=True,
+        *args,
+        **kwargs
+    ):
 
         self._signal_template = signal.SignalTemplate.load_from_stackfiles(
             pattern,
             factor=factor,
+            pol=pol,
+            weight=weight,
+            combine=combine,
+            sort=sort,
             aliases=dict(shotnoise="M_10"),
         )
 
-        self.param_name = list(self._param_spec.keys())
-
         super().__init__(*args, **kwargs)
 
-    def model(self, theta, freq=None, **kwargs):
+    def model(self, theta, freq=None, transfer=None, pol_sel=None):
 
         if freq is None:
             freq = self.freq
 
-        param_dict = {k: v for k, v in zip(self._param_spec.keys(), theta)}
+        if transfer is None:
+            transfer = self.transfer
 
-        offset = theta[0]
+        if pol_sel is None:
+            pol_sel = self.pol_sel
 
-        # Compute the model and extract the XX and YY polarisations
-        model_init = self._signal_template.signal(**param_dict)[[0, 3]]
+        param_dict = {k: v for k, v in zip(self.param_name, theta)}
 
-        model = utils.shift_and_convolve(freq, model_init, offset=offset, kernel=None)
+        offset = param_dict.pop("offset")
+
+        model_init = self._signal_template.signal(**param_dict)[pol_sel]
+
+        model = utils.shift_and_convolve(
+            freq, model_init, offset=offset, kernel=transfer
+        )
 
         return model
-
-
-# TODO: this would probably be cleaner if we could pass parameters through to the model
-# constructors
-class SimulationTemplateQSONGC(SimulationTemplateBase):
-    tracer = "QSO"
-    field = "NGC"


### PR DESCRIPTION
* Capability to pass model kwargs from config file
to model class constructor.

* Remove SimulationTemplateQSONGC class.
The pattern used to look up the simulation
templates is now provided in the config file
under model_kwargs.

* Remove signal.stack_av, signal.stack_av_group,
and signal.load_all and replace with the
equivalent functions from utils, which allows
selecting the polarisations and sorting of the
frequency axis in the same manner as the data and mocks.

* Update default boundaries for SimulationTemplate class.

* Create utils.load_pol function that load a data file into
the proper container with the requested polarisations.

* Create utils.average_stacks to average over mock catalogs.
Use that when constructing average template.

* Add fixed dataset that indicates the parameters held fixed
during the fit.

* Fixed a bug and can now hold parameters fixed by setting
the fixed keyword to True in the param_spec.

* Combine the _param_spec from all subclasses.